### PR TITLE
Fix PostCSS config to load Tailwind plugin directly

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
+import tailwindcss from 'tailwindcss'
+import autoprefixer from 'autoprefixer'
+
 export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+  plugins: [tailwindcss, autoprefixer],
 }


### PR DESCRIPTION
## Summary
- load the tailwindcss and autoprefixer plugins explicitly in the PostCSS config to avoid resolution errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dab4dc354483328e918269c61d9494