### PR TITLE
Set up App layout structure

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,19 @@
+import { About } from "./components/About"
+import { Footer } from "./components/Footer"
+import { Header } from "./components/Header"
+import { Hero } from "./components/Hero"
+import { Projects } from "./components/Projects"
+
 export default function App() {
   return (
-    <>
-    </>
+    <div className="size-full">
+      <Header />
+      <main>
+        <Hero />
+        <Projects />
+        <About />
+        <Footer />
+      </main>
+    </div>
   )
 }

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,0 +1,3 @@
+export function About() {
+  return <section />
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,3 @@
+export function Header() {
+  return <header />
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,3 @@
+export function Hero() {
+  return <section />
+}

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,0 +1,3 @@
+export function Projects() {
+  return <section />
+}


### PR DESCRIPTION
## Summary
- wire the app layout to render the header, main sections, and footer inside a full-size wrapper
- add minimal component exports for Header, Hero, Projects, and About so they can be imported

## Testing
- `npm run build` *(fails: TypeScript cannot resolve the `lucide-react` module used in `Footer`)*

------
https://chatgpt.com/codex/tasks/task_e_68daccd39af88332aa8826d604147af0