### PR TITLE
Implement portfolio sections and smooth scrolling

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,3 +1,54 @@
 export function About() {
-  return <section />
+  return (
+    <section
+      id="about"
+      className="mx-auto max-w-5xl px-6 py-24"
+    >
+      <div className="grid gap-12 md:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]">
+        <div className="space-y-6">
+          <h2 className="text-3xl font-bold tracking-tight text-neutral-900 sm:text-4xl">
+            About me
+          </h2>
+          <p className="text-neutral-600">
+            I'm a product-focused developer with a background in design. I love
+            building accessible experiences and finding the balance between
+            delightful interactions and measurable outcomes.
+          </p>
+          <p className="text-neutral-600">
+            Over the last few years I've worked with startups and agencies to
+            launch marketing sites, SaaS platforms, and internal tooling. I enjoy
+            partnering closely with designers, product managers, and engineers to
+            craft solutions that scale.
+          </p>
+          <p className="text-neutral-600">
+            When I'm not at the keyboard you can find me exploring local coffee
+            shops, learning new animation techniques, or mentoring emerging
+            developers.
+          </p>
+        </div>
+
+        <div className="space-y-4 rounded-2xl border border-neutral-200 bg-neutral-50 p-6">
+          <h3 className="text-lg font-semibold text-neutral-900">Skills & tools</h3>
+          <dl className="grid gap-4 text-sm text-neutral-600 sm:grid-cols-2">
+            <div>
+              <dt className="font-medium text-neutral-900">Languages</dt>
+              <dd>TypeScript, JavaScript, HTML, CSS</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-neutral-900">Frameworks</dt>
+              <dd>React, Next.js, Remix, Astro</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-neutral-900">Styling</dt>
+              <dd>Tailwind CSS, CSS Modules, Styled Components</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-neutral-900">Workflow</dt>
+              <dd>Design systems, Accessibility, Design handoff</dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+    </section>
+  )
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,15 @@ import { Github, Linkedin, Mail } from "lucide-react"
 
 export function Footer() {
   return (
-    <footer className="flex flex-col items-center gap-4 py-6 text-sm text-neutral-500">
+    <footer
+      id="contact"
+      className="mx-auto flex max-w-5xl flex-col items-center gap-4 px-6 py-12 text-sm text-neutral-500"
+    >
+      <h2 className="text-base font-semibold text-neutral-900">Let's work together</h2>
+      <p className="text-center text-neutral-600">
+        Have a project in mind or want to collaborate? Reach out through any of
+        the channels below.
+      </p>
       <div className="flex items-center gap-4">
         <a
           aria-label="Email"
@@ -15,6 +23,8 @@ export function Footer() {
           aria-label="GitHub"
           className="transition-colors hover:text-neutral-900"
           href="https://github.com/username"
+          rel="noreferrer"
+          target="_blank"
         >
           <Github className="size-5" />
         </a>
@@ -22,6 +32,8 @@ export function Footer() {
           aria-label="LinkedIn"
           className="transition-colors hover:text-neutral-900"
           href="https://linkedin.com/in/username"
+          rel="noreferrer"
+          target="_blank"
         >
           <Linkedin className="size-5" />
         </a>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,3 +1,54 @@
-export function Header() {
-  return <header />
+const NAV_ITEMS = [
+  { label: "Home", target: "hero" },
+  { label: "Projects", target: "projects" },
+  { label: "About", target: "about" },
+  { label: "Contact", target: "contact" },
+]
+
+function scrollToSection(id: string) {
+  const element = document.getElementById(id)
+
+  if (element) {
+    element.scrollIntoView({ behavior: "smooth", block: "start" })
+  }
 }
+
+export function Header() {
+  return (
+    <header className="sticky top-0 z-50 border-b border-neutral-200 bg-white/80 backdrop-blur">
+      <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+        <a
+          className="text-lg font-semibold tracking-tight text-neutral-900 transition-colors hover:text-neutral-600"
+          href="#hero"
+          onClick={(event) => {
+            event.preventDefault()
+            scrollToSection("hero")
+          }}
+        >
+          Your Name
+        </a>
+
+        <nav aria-label="Primary">
+          <ul className="flex items-center gap-6 text-sm font-medium text-neutral-600">
+            {NAV_ITEMS.map((item) => (
+              <li key={item.target}>
+                <a
+                  className="transition-colors hover:text-neutral-900"
+                  href={`#${item.target}`}
+                  onClick={(event) => {
+                    event.preventDefault()
+                    scrollToSection(item.target)
+                  }}
+                >
+                  {item.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </div>
+    </header>
+  )
+}
+
+export { scrollToSection }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,3 +1,50 @@
-export function Hero() {
-  return <section />
+import { scrollToSection } from "./Header"
+
+function scrollToProjects() {
+  scrollToSection("projects")
 }
+
+export function Hero() {
+  return (
+    <section
+      id="hero"
+      className="mx-auto flex max-w-5xl flex-col items-start gap-10 px-6 pb-24 pt-28 text-neutral-900"
+    >
+      <p className="text-sm font-semibold uppercase tracking-[0.2em] text-blue-600">
+        Hi, I'm Your Name
+      </p>
+      <div className="space-y-6">
+        <h1 className="text-4xl font-bold tracking-tight text-neutral-900 sm:text-5xl">
+          Crafting thoughtful web experiences with modern tools and a focus on
+          usability.
+        </h1>
+        <p className="max-w-2xl text-lg text-neutral-600">
+          I'm a front-end engineer who loves building performant, accessible
+          interfaces. I enjoy collaborating with teams to transform complex
+          problems into intuitive products.
+        </p>
+      </div>
+      <div className="flex flex-wrap items-center gap-4">
+        <button
+          className="rounded-full bg-neutral-900 px-6 py-3 text-sm font-medium text-white transition hover:bg-neutral-700"
+          onClick={scrollToProjects}
+          type="button"
+        >
+          View Projects
+        </button>
+        <a
+          className="text-sm font-medium text-neutral-700 underline-offset-4 transition hover:underline"
+          href="#contact"
+          onClick={(event) => {
+            event.preventDefault()
+            scrollToSection("contact")
+          }}
+        >
+          Get in touch
+        </a>
+      </div>
+    </section>
+  )
+}
+
+export { scrollToProjects }

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,0 +1,51 @@
+export type Project = {
+  title: string
+  description: string
+  tech: string[]
+  liveUrl?: string
+  repoUrl?: string
+}
+
+export function ProjectCard({ title, description, tech, liveUrl, repoUrl }: Project) {
+  return (
+    <article className="flex h-full flex-col justify-between rounded-xl border border-neutral-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-lg">
+      <div className="space-y-3">
+        <h3 className="text-lg font-semibold text-neutral-900">{title}</h3>
+        <p className="text-sm text-neutral-600">{description}</p>
+        <ul className="flex flex-wrap gap-2 text-xs font-medium uppercase tracking-wide text-neutral-500">
+          {tech.map((item) => (
+            <li
+              className="rounded-full border border-neutral-200 px-3 py-1"
+              key={item}
+            >
+              {item}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="mt-6 flex items-center gap-4 text-sm font-medium">
+        {liveUrl && (
+          <a
+            className="text-blue-600 transition hover:text-blue-700"
+            href={liveUrl}
+            rel="noreferrer"
+            target="_blank"
+          >
+            View live
+          </a>
+        )}
+        {repoUrl && (
+          <a
+            className="text-neutral-600 transition hover:text-neutral-900"
+            href={repoUrl}
+            rel="noreferrer"
+            target="_blank"
+          >
+            Source code
+          </a>
+        )}
+      </div>
+    </article>
+  )
+}

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,3 +1,53 @@
+import { ProjectCard, type Project } from "./ProjectCard"
+
+const PROJECTS: Project[] = [
+  {
+    title: "Design System Dashboard",
+    description:
+      "A component-driven dashboard for managing a company design system with live previews and guidelines.",
+    tech: ["React", "TypeScript", "Tailwind"],
+    liveUrl: "https://example.com/design-system",
+    repoUrl: "https://github.com/username/design-system-dashboard",
+  },
+  {
+    title: "SaaS Analytics Platform",
+    description:
+      "Interactive analytics dashboards with real-time data visualizations and customizable reporting.",
+    tech: ["Next.js", "D3.js", "PostgreSQL"],
+    liveUrl: "https://example.com/saas-analytics",
+    repoUrl: "https://github.com/username/saas-analytics",
+  },
+  {
+    title: "E-commerce Storefront",
+    description:
+      "A performant storefront with advanced search, persistent cart, and server-side rendering for SEO.",
+    tech: ["Remix", "Prisma", "Stripe"],
+    liveUrl: "https://example.com/storefront",
+    repoUrl: "https://github.com/username/ecommerce-storefront",
+  },
+]
+
 export function Projects() {
-  return <section />
+  return (
+    <section
+      id="projects"
+      className="mx-auto max-w-5xl px-6 py-24"
+    >
+      <div className="mb-12 flex flex-col gap-4">
+        <h2 className="text-3xl font-bold tracking-tight text-neutral-900 sm:text-4xl">
+          Selected work
+        </h2>
+        <p className="max-w-2xl text-neutral-600">
+          A snapshot of the products and experiments I've been building recently.
+          Each project blends thoughtful UX with scalable engineering.
+        </p>
+      </div>
+
+      <div className="grid gap-8 sm:grid-cols-2">
+        {PROJECTS.map((project) => (
+          <ProjectCard key={project.title} {...project} />
+        ))}
+      </div>
+    </section>
+  )
 }

--- a/src/types/lucide-react.d.ts
+++ b/src/types/lucide-react.d.ts
@@ -1,0 +1,11 @@
+declare module "lucide-react" {
+  import * as React from "react"
+
+  type Icon = React.ForwardRefExoticComponent<
+    React.ComponentPropsWithoutRef<"svg"> & React.RefAttributes<SVGSVGElement>
+  >
+
+  export const Github: Icon
+  export const Linkedin: Icon
+  export const Mail: Icon
+}


### PR DESCRIPTION
## Summary
- build header navigation with smooth scrolling helper
- add hero, projects, about, and contact sections with tailored content
- create reusable project card component and type definitions for icon imports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dace3901548332923df92fe3746f7f