### PR TITLE
feat: improve image fallback handling

### DIFF
--- a/src/components/figma/ImageWithFallback.tsx
+++ b/src/components/figma/ImageWithFallback.tsx
@@ -1,45 +1,57 @@
-import type { ImgHTMLAttributes, ReactNode, SyntheticEvent } from "react";
-import { useState } from "react";
+import { useEffect, useMemo, useState, type ImgHTMLAttributes, type ReactNode, type SyntheticEvent } from "react";
 
 import { cn } from "../ui/utils";
 
 type ImageWithFallbackProps = ImgHTMLAttributes<HTMLImageElement> & {
+  /**
+   * Optional React node to render when the image fails to load.
+   * When omitted, the component will render a subtle default placeholder.
+   */
   fallback?: ReactNode;
 };
 
-export function ImageWithFallback({
+const defaultFallback = (
+  <div className="flex flex-col items-center justify-center gap-2 text-gray-500">
+    <span className="text-sm font-medium">Image unavailable</span>
+    <span className="text-xs text-gray-400">Unable to load preview</span>
+  </div>
+);
+
+export const ImageWithFallback = ({
   fallback,
   className,
   onError,
+  src,
   ...props
-}: ImageWithFallbackProps) {
+}: ImageWithFallbackProps) => {
   const [hasError, setHasError] = useState(false);
+
+  // Reset the error state when the source changes so new images can render.
+  useEffect(() => {
+    setHasError(false);
+  }, [src]);
 
   const handleError = (event: SyntheticEvent<HTMLImageElement, Event>) => {
     setHasError(true);
     onError?.(event);
   };
 
-  if (hasError) {
-    if (fallback) {
-      return (
-        <div className={cn("flex h-full w-full items-center justify-center bg-gray-100", className)}>
-          {fallback}
-        </div>
-      );
-    }
+  const shouldShowFallback = hasError || !src;
 
+  const fallbackContent = useMemo(() => fallback ?? defaultFallback, [fallback]);
+
+  if (shouldShowFallback) {
     return (
       <div
         className={cn(
-          "flex h-full w-full items-center justify-center bg-gray-100 text-sm font-medium text-gray-500",
+          "flex h-full w-full items-center justify-center bg-gray-100",
           className,
         )}
       >
-        Image unavailable
+        {fallbackContent}
       </div>
     );
   }
 
-  return <img {...props} className={cn(className)} onError={handleError} />;
-}
+  return <img {...props} src={src} className={cn("h-full w-full object-cover", className)} onError={handleError} />;
+};


### PR DESCRIPTION
## Summary
- implement the ImageWithFallback helper as a const export with enhanced placeholder rendering
- reset the error state when the source changes and provide a default placeholder when the image is unavailable
- ensure fallback views preserve the intended sizing and cover behavior for ProjectCard artwork

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dad876bdd483329eb792cecf54de7c