### PR TITLE
feat: align tailwind theme colors with design palette

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,26 @@
     --color-neutral-700: #334155;
     --color-neutral-900: #0f172a;
 
+    --background: var(--color-surface-50);
+    --foreground: var(--color-neutral-900);
+    --card: #ffffff;
+    --card-foreground: var(--color-neutral-900);
+    --popover: #ffffff;
+    --popover-foreground: var(--color-neutral-900);
+    --primary: #4f46e5;
+    --primary-foreground: #ffffff;
+    --secondary: #e0e7ff;
+    --secondary-foreground: #312e81;
+    --muted: #f1f5f9;
+    --muted-foreground: var(--color-neutral-500);
+    --accent: #06b6d4;
+    --accent-foreground: #022c3a;
+    --destructive: #ef4444;
+    --destructive-foreground: #ffffff;
+    --border: #e2e8f0;
+    --input: #e2e8f0;
+    --ring: #4f46e5;
+
     --radius-xs: 0.375rem;
     --radius-sm: 0.5rem;
     --radius-md: 0.75rem;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,53 @@ const config = {
   content: ['./index.html', './src/**/*.{ts,tsx,css}'],
   darkMode: 'class',
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        border: 'var(--border)',
+        input: 'var(--input)',
+        ring: 'var(--ring)',
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
+        primary: {
+          DEFAULT: 'var(--primary)',
+          foreground: 'var(--primary-foreground)',
+        },
+        secondary: {
+          DEFAULT: 'var(--secondary)',
+          foreground: 'var(--secondary-foreground)',
+        },
+        destructive: {
+          DEFAULT: 'var(--destructive)',
+          foreground: 'var(--destructive-foreground)',
+        },
+        accent: {
+          DEFAULT: 'var(--accent)',
+          foreground: 'var(--accent-foreground)',
+        },
+        muted: {
+          DEFAULT: 'var(--muted)',
+          foreground: 'var(--muted-foreground)',
+        },
+        popover: {
+          DEFAULT: 'var(--popover)',
+          foreground: 'var(--popover-foreground)',
+        },
+        card: {
+          DEFAULT: 'var(--card)',
+          foreground: 'var(--card-foreground)',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius-lg)',
+        md: 'var(--radius-md)',
+        sm: 'var(--radius-sm)',
+      },
+      boxShadow: {
+        xs: 'var(--shadow-xs)',
+        sm: 'var(--shadow-sm)',
+        md: 'var(--shadow-md)',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- map the tailwind theme color tokens to the design palette via CSS variables
- extend Tailwind's color, radius, and shadow settings so Button variants render with the intended Apple-inspired styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dad9ed4d0083329c8241efbaefe6df