### PR TITLE
refactor: replace scrollToSection with anchor-based smooth scrolling

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,38 +1,21 @@
 import { Button } from "./ui/button";
 
 export function Header() {
-  const scrollToSection = (sectionId: string) => {
-    const element = document.getElementById(sectionId);
-    element?.scrollIntoView({ behavior: 'smooth' });
-  };
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-md border-b border-gray-100">
       <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
-        <div className="cursor-pointer" onClick={() => scrollToSection('hero')}>
-          <span className="font-medium text-lg">BoDee Angus</span>
-        </div>
+        <a href="#hero" className="font-medium text-lg">BoDee Angus</a>
 
         <nav className="hidden md:flex items-center space-x-2">
-          <button
-            onClick={() => scrollToSection('projects')}
-            className="text-gray-600 hover:text-gray-900 hover:bg-gray-100 px-4 py-2 rounded-lg transition-all duration-200 ease-out"
-          >
+          <a href="#projects" className="text-gray-600 hover:text-gray-900 hover:bg-gray-100 px-4 py-2 rounded-lg">
             Projects
-          </button>
-          <button
-            onClick={() => scrollToSection('about')}
-            className="text-gray-600 hover:text-gray-900 hover:bg-gray-100 px-4 py-2 rounded-lg transition-all duration-200 ease-out"
-          >
+          </a>
+          <a href="#about" className="text-gray-600 hover:text-gray-900 hover:bg-gray-100 px-4 py-2 rounded-lg">
             About
-          </button>
-          <Button
-            onClick={() => scrollToSection('contact')}
-            variant="default"
-            size="sm"
-            className="bg-black text-white hover:bg-gray-800 ml-4 transition-all duration-200 ease-out hover:scale-[0.98]"
-          >
-            Contact
+          </a>
+          <Button asChild size="sm" className="bg-black text-white hover:bg-gray-800 ml-4 transition-all duration-200 ease-out hover:scale-[0.98]">
+            <a href="#contact">Contact</a>
           </Button>
         </nav>
       </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,10 +2,6 @@ import { Button } from "./ui/button";
 import { motion } from "motion/react";
 
 export function Hero() {
-  const scrollToProjects = () => {
-    const element = document.getElementById('projects');
-    element?.scrollIntoView({ behavior: 'smooth' });
-  };
 
   return (
     <section id="hero" className="min-h-screen flex items-center justify-center px-6 bg-gradient-to-b from-white to-gray-50">
@@ -28,11 +24,11 @@ export function Hero() {
             transition={{ duration: 0.8, delay: 0.3 }}
           >
             <Button
-              onClick={scrollToProjects}
+              asChild
               size="lg"
               className="bg-black text-white hover:bg-gray-800 px-8 py-3 rounded-full"
             >
-              View My Work
+              <a href="#projects">View My Work</a>
             </Button>
           </motion.div>
         </motion.div>

--- a/src/globals.css
+++ b/src/globals.css
@@ -1,5 +1,11 @@
 @import "tailwindcss";
 
+@layer base {
+  html {
+    scroll-behavior: smooth;
+  }
+}
+
 :root {
   --font-size: 16px;
   --background: #fff;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,28 @@ import { createRoot } from 'react-dom/client'
 import './globals.css'
 import App from './App.tsx'
 
+if (window.location.hash) {
+  const nav = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
+  if (nav?.type === 'reload') {
+    history.replaceState(null, '', window.location.pathname + window.location.search);
+    window.scrollTo({ top: 0, behavior: 'auto' });
+  }
+}
+
+if ('scrollRestoration' in history) {
+  history.scrollRestoration = 'manual';
+}
+
+// After the page is shown (including bfcache restores), if there's no hash,
+// force a top-of-page position *after* layout paints once.
+window.addEventListener('pageshow', () => {
+  if (!location.hash) {
+    requestAnimationFrame(() => {
+      window.scrollTo({ top: 0, behavior: 'auto' });
+    });
+  }
+});
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
### Summary
Replaced JS-based scrolling with native anchor links + CSS smooth scrolling.

### Changes
- Removed scrollToSection/scrollToProjects helpers
- Added `@layer base { html { scroll-behavior: smooth } }`
- Converted Header/Hero buttons to anchors (Contact uses Button `asChild`)

### Why
Simpler, more accessible, no duplicate logic.

### Testing
- Clicking nav/hero links scrolls smoothly and sets hash.
- Reload without hash starts at top (manual scroll restoration in main.tsx).
